### PR TITLE
Update AutoloadMap\AutoloadMap

### DIFF
--- a/src/AutoloadMap.hack
+++ b/src/AutoloadMap.hack
@@ -12,15 +12,5 @@ namespace Facebook\AutoloadMap;
 /** The main shape of an autoload map.
  *
  * Must match `\HH\autoload_set_paths()`
- * However, this is nolonger accurate.
- * The parameter of autoload_set_paths is a
- * `KeyedContainer<string, KeyedContainer<string, string>>`.
- * This does sadly not allow for the fallback key,
- * which is a (function(string, string): bool).
  */
-type AutoloadMap = shape(
-  'class' => darray<string, string>,
-  'function' => darray<string, string>,
-  'type' => darray<string, string>,
-  'constant' => darray<string, string>,
-);
+type AutoloadMap = dict<string, dict<string, string>>;

--- a/src/Merger.hack
+++ b/src/Merger.hack
@@ -23,18 +23,18 @@ abstract final class Merger {
    * In the case of duplicates, the last definition is used.
    */
   public static function merge(vec<AutoloadMap> $maps): AutoloadMap {
-    return shape(
+    return dict[
       'class' => self::mergeImpl(Vec\map($maps, $map ==> $map['class'])),
       'function' => self::mergeImpl(Vec\map($maps, $map ==> $map['function'])),
       'type' => self::mergeImpl(Vec\map($maps, $map ==> $map['type'])),
       'constant' => self::mergeImpl(Vec\map($maps, $map ==> $map['constant'])),
-    );
+    ];
   }
 
   private static function mergeImpl(
     Traversable<KeyedTraversable<string, string>> $maps,
-  ): darray<string, string> {
-    $out = darray[];
+  ): dict<string, string> {
+    $out = dict[];
     foreach ($maps as $map) {
       foreach ($map as $def => $file) {
         $out[$def] = $file;

--- a/src/Writer.hack
+++ b/src/Writer.hack
@@ -137,10 +137,13 @@ final class Writer {
 
     $map = \array_map(
       ($sub_map): mixed ==> {
-        assert(\is_array($sub_map));
-        return \array_map($path ==> $this->relativePath($path), $sub_map);
+        assert($sub_map is KeyedContainer<_, _>);
+        return \array_map(
+          $path ==> $this->relativePath($path as string),
+          $sub_map,
+        );
       },
-      Shapes::toArray($map),
+      $map,
     );
 
     $failure_handler = $this->failureHandler;
@@ -171,7 +174,7 @@ final class Writer {
     );
 
     $map = \var_export($map, true)
-      |> \str_replace('array (', 'darray[', $$)
+      |> \str_replace('array (', 'dict[', $$)
       |> \str_replace(')', ']', $$);
 
     if ($this->relativeAutoloadRoot) {

--- a/src/builders/FactParseScanner.hack
+++ b/src/builders/FactParseScanner.hack
@@ -113,10 +113,10 @@ final class FactParseScanner implements Builder {
     );
     $facts = self::untypedToShape($facts);
 
-    $classes = darray[];
-    $functions = darray[];
-    $types = darray[];
-    $constants = darray[];
+    $classes = dict[];
+    $functions = dict[];
+    $types = dict[];
+    $constants = dict[];
     foreach ($facts as $file => $file_facts) {
       foreach ($file_facts['types'] as $type) {
         $classes[\strtolower($type['name'])] = $file;
@@ -131,12 +131,12 @@ final class FactParseScanner implements Builder {
         $types[\strtolower($alias)] = $file;
       }
     }
-    return shape(
+    return dict[
       'class' => $classes,
       'function' => $functions,
       'type' => $types,
       'constant' => $constants,
-    );
+    ];
   }
 
   public function getFiles(): vec<string> {

--- a/tests/ConfigurationLoaderTest.hack
+++ b/tests/ConfigurationLoaderTest.hack
@@ -15,9 +15,9 @@ use function Facebook\FBExpect\expect;
 final class ConfigurationLoaderTest extends \Facebook\HackTest\HackTest {
   const IGNORED_VALUE = '__ignore__';
 
-  public function goodTestCases(): dict<string, (darray<string, mixed>)> {
+  public function goodTestCases(): dict<string, (dict<string, mixed>)> {
     return dict[
-      'fully specified' => tuple(darray[
+      'fully specified' => tuple(dict[
         'autoloadFilesBehavior' => self::IGNORED_VALUE,
         'relativeAutoloadRoot' => false,
         'includeVendor' => false,
@@ -25,24 +25,24 @@ final class ConfigurationLoaderTest extends \Facebook\HackTest\HackTest {
         'roots' => vec['foo/', 'bar/'],
         'parser' => 'ext-factparse',
       ]),
-      'just roots' => tuple(darray['roots' => vec['foo/', 'bar/']]),
+      'just roots' => tuple(dict['roots' => vec['foo/', 'bar/']]),
     ];
   }
 
   <<DataProvider('goodTestCases')>>
-  public function testDataLoader(array<string, mixed> $data): void {
+  public function testDataLoader(dict<string, mixed> $data): void {
     $config = ConfigurationLoader::fromData($data, '/dev/null');
     $this->assertGoodConfig($data, $config);
   }
 
   <<DataProvider('goodTestCases')>>
-  public function testJSONLoader(array<string, mixed> $data): void {
+  public function testJSONLoader(dict<string, mixed> $data): void {
     $config = ConfigurationLoader::fromJSON(\json_encode($data), '/dev/null');
     $this->assertGoodConfig($data, $config);
   }
 
   <<DataProvider('goodTestCases')>>
-  public function testFileLoader(array<string, mixed> $data): void {
+  public function testFileLoader(dict<string, mixed> $data): void {
     $fname = \tempnam(\sys_get_temp_dir(), 'testjson');
     try {
       \file_put_contents($fname, \json_encode($data));
@@ -54,7 +54,7 @@ final class ConfigurationLoaderTest extends \Facebook\HackTest\HackTest {
   }
 
   private function assertGoodConfig(
-    array<string, mixed> $data,
+    dict<string, mixed> $data,
     Config $config,
   ): void {
     expect($config['roots'])->toEqual($data['roots']);

--- a/tests/ScannerTest.hack
+++ b/tests/ScannerTest.hack
@@ -83,8 +83,8 @@ final class ScannerTest extends BaseTest {
   }
 
   private function assertMapMatches(
-    KeyedContainer<string, string> $expected,
-    KeyedContainer<string, string> $actual,
+    dict<string, string> $expected,
+    dict<string, string> $actual,
   ): void {
     foreach ($expected as $name => $file) {
       $a = self::HH_ONLY_SRC.'/'.$file;


### PR DESCRIPTION
This change might not be for the better.
The HH\autoload_set_paths() function is still wrong.
The failure key is not of type string.
It should be a callable.